### PR TITLE
Finish up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: freckle/stack-cache-action@v1
+      - uses: freckle/stack-action@v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: freckle/stack-cache-action@v1
       - uses: freckle/stack-action@v1.1
+        with:
+          weeder: false
 
       - name: Adjust Freckle maintainers
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: freckle/stack-cache-action@v1
-      - uses: freckle/stack-action@v1.1
+      - uses: freckle/stack-action@main
         with:
           weeder: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,17 @@ jobs:
       - uses: actions/checkout@v2
       - uses: freckle/stack-cache-action@v1
       - uses: freckle/stack-action@v1.1
+
+      - name: Adjust Freckle maintainers
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
+        run: |
+          # Additions can be auto-fixed
+          stack exec hackage-team -- --no-remove --fix \
+            < ./FRECKLE_MAINTAINERS.txt
+
+          # Removals should fail the build and be manually fixed. Also sendgrid
+          # is expected to have extra users so we skip that.
+          stack exec hackage-team -- --no-add --exclude sendgrid-v3 \
+            < ./FRECKLE_MAINTAINERS.txt

--- a/FRECKLE_MAINTAINERS.txt
+++ b/FRECKLE_MAINTAINERS.txt
@@ -1,0 +1,6 @@
+PatrickBrisbin
+cbeav
+cdparks
+dukerutledge
+halogenandtoast
+mjgpy3

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,8 @@ import HackageTeam.Run
 
 main :: IO ()
 main = do
-  options <- parseOptions
+  options@Options {..} <- parseOptions
   maintainers <- getMaintainers
   app <- loadApp options
-  runAppT app $ run options maintainers
+  checkFailed <- runAppT app $ execStateT (run options maintainers) False
+  when (checkFailed && not oFix && not oExitZero) exitFailure

--- a/hackage-team.cabal
+++ b/hackage-team.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51660e99302eeab299ac37aa50bb031d84609a39a944cd3845fcf1e701be22fa
+-- hash: 7125c7592c4b5386e094656b812175266abaed7b9df144ea621620c9e7321896
 
 name:           hackage-team
 version:        0.0.0.1
@@ -48,6 +48,7 @@ library
     , http-conduit
     , http-types
     , monad-logger
+    , mtl
     , optparse-applicative
     , rio
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ library:
     - http-conduit
     - http-types
     - monad-logger
+    - mtl
     - optparse-applicative
     - rio
 

--- a/package.yaml
+++ b/package.yaml
@@ -72,7 +72,6 @@ executables:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
-
 # tests:
 #   spec:
 #     main: Spec.hs

--- a/src/HackageTeam/HackageApi.hs
+++ b/src/HackageTeam/HackageApi.hs
@@ -26,3 +26,10 @@ class Monad m => MonadHackage m where
   addPackageMaintainer :: Package -> HackageUsername -> m ()
 
   removePackageMaintainer :: Package -> HackageUsername -> m ()
+
+instance MonadHackage m => MonadHackage (StateT s m) where
+  getSelf = lift getSelf
+  getMaintainedPackages x = lift $ getMaintainedPackages x
+  getPackageMaintainers x = lift $ getPackageMaintainers x
+  addPackageMaintainer x y = lift $ addPackageMaintainer x y
+  removePackageMaintainer x y = lift $ removePackageMaintainer x y

--- a/src/HackageTeam/HackageApi/Actual.hs
+++ b/src/HackageTeam/HackageApi/Actual.hs
@@ -105,6 +105,40 @@ instance (MonadIO m, MonadReader env m, HasHackageApiKey env)
       <> unpack name
       <> "/maintainers/"
 
-  addPackageMaintainer = undefined
+  addPackageMaintainer (Package name) (HackageUsername user) = do
+    bs <- view $ hackageApiKeyL . unL
 
-  removePackageMaintainer = undefined
+    let
+      reason :: Text
+      reason = "Added by freckle/hackage-team"
+
+    void
+      $ httpNoBody
+      $ addApiKeyAuthorization bs
+      $ addToRequestQueryString
+          [ ("user", Just $ encodeUtf8 user)
+          , ("reason", Just $ encodeUtf8 reason)
+          ]
+      $ setRequestCheckStatus
+      $ parseRequest_
+      $ "POST https://hackage.haskell.org/package/"
+      <> unpack name
+      <> "/maintainers/"
+
+  removePackageMaintainer (Package name) (HackageUsername user) = do
+    bs <- view $ hackageApiKeyL . unL
+
+    let
+      reason :: Text
+      reason = "Removed by freckle/hackage-team"
+
+    void
+      $ httpNoBody
+      $ addApiKeyAuthorization bs
+      $ addToRequestQueryString [("reason", Just $ encodeUtf8 reason)]
+      $ setRequestCheckStatus
+      $ parseRequest_
+      $ "DELETE https://hackage.haskell.org/package/"
+      <> unpack name
+      <> "/maintainers/user/"
+      <> unpack user

--- a/src/HackageTeam/Options.hs
+++ b/src/HackageTeam/Options.hs
@@ -14,6 +14,7 @@ data Options = Options
   , oSuppressRemoves :: Bool
   , oExclude :: [Package]
   , oFix :: Bool
+  , oExitZero :: Bool
   , oVerbose :: Bool
   }
 
@@ -50,6 +51,10 @@ options =
     <*> switch
       (  long "fix"
       <> help "Actually add/remove as required"
+      )
+    <*> switch
+      (  long "exit-zero"
+      <> help "Exit zero even if unfixed issues were found"
       )
     <*> switch
       (  long "verbose"

--- a/src/HackageTeam/Prelude.hs
+++ b/src/HackageTeam/Prelude.hs
@@ -25,6 +25,7 @@ import RIO as X hiding
 
 import Control.Monad.Logger as X hiding
   (logDebug, logError, logInfo, logOther, logWarn)
+import Control.Monad.State as X
 import RIO.Text as X (pack, unpack)
 
 logError :: MonadLogger m => Utf8Builder -> m ()

--- a/src/HackageTeam/Run.hs
+++ b/src/HackageTeam/Run.hs
@@ -10,7 +10,11 @@ import HackageTeam.Options
 import qualified RIO.ByteString as BS
 import qualified RIO.Text as T
 
-run :: (MonadLogger m, MonadHackage m) => Options -> [HackageUsername] -> m ()
+run
+  :: (MonadState Bool m, MonadLogger m, MonadHackage m)
+  => Options
+  -> [HackageUsername]
+  -> m ()
 run Options {..} expectedMaintainers = do
   username <- getSelf
   logDebug $ "Running as Maintainer: " <> display username
@@ -26,12 +30,14 @@ run Options {..} expectedMaintainers = do
     unless oSuppressAdds
       $ for_ (filter (`notElem` maintainers) expectedMaintainers)
       $ \maintainer -> do
+          put True
           logInfo $ "Expected, not present: " <> display maintainer
           when oFix $ addPackageMaintainer package maintainer
 
     unless oSuppressRemoves
       $ for_ (filter (`notElem` expectedMaintainers) maintainers)
       $ \maintainer -> do
+          put True
           logInfo $ "Present, not expected: " <> display maintainer
           when oFix $ removePackageMaintainer package maintainer
 

--- a/src/HackageTeam/Run.hs
+++ b/src/HackageTeam/Run.hs
@@ -31,14 +31,14 @@ run Options {..} expectedMaintainers = do
       $ for_ (filter (`notElem` maintainers) expectedMaintainers)
       $ \maintainer -> do
           put True
-          logInfo $ "Expected, not present: " <> display maintainer
+          logWarn $ "Expected, not present: " <> display maintainer
           when oFix $ addPackageMaintainer package maintainer
 
     unless oSuppressRemoves
       $ for_ (filter (`notElem` expectedMaintainers) maintainers)
       $ \maintainer -> do
           put True
-          logInfo $ "Present, not expected: " <> display maintainer
+          logWarn $ "Present, not expected: " <> display maintainer
           when oFix $ removePackageMaintainer package maintainer
 
 -- | Read a list of expected maintainers, one per line, on @stdin@


### PR DESCRIPTION
Separate commits:

- Add GitHub Actions

- Add current Freckle maintainers list

- Implement actual add/remove

- Exit non-zero if issues were found

  - Only if we didn't also --fix them
  - Behavior can be disabled with --exit-zero

- Log warnings at WARNING

- Adjust Freckle maintainers automatically on CI

  As automatically as we can, anyway. Leave removals to be manually fixed.