### PR TITLE
Add schedule to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: main
+    
+  schedule:
+    - cron: "0 0 * * 1" # every monday at midnight UTC
 
   workflow_dispatch:
 


### PR DESCRIPTION
This will remove the last manual step when releasing a new OSS package to Hackage. Now, the maintainers will be updated automatically within a week.

I chose to do it weekly because it really doesn't matter if it doesn't happen for a while -- auto-release from CI will  always work from the jump, and this is more about ensuring all our engineers have maintainer rights in case manual intervention is needed for some reason.