### PR TITLE
Skip check-uploader-packages for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./.github/bin/check-uploader-packages
+      - if: ${{ github.actor != 'dependabot[bot]' }}
+        run: ./.github/bin/check-uploader-packages
         env:
           DRY_RUN: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This step requires a secret, so let's skip it for Dependabot. I chose to skip the step not the job because skipping the whole job would also make `test` skip.